### PR TITLE
Automatisation du chargement des données de RDV Service Public

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -1,0 +1,8 @@
+{
+  "jobs": [
+    {
+      "command": "30 4 * * 1-5 bundle exec ruby main.rb --app rdvsp",
+      "_comment": "// Chargement des données de RDV Service Public à 4h30 du matin UTC du lundi au vendredi"
+    },
+  ]
+}


### PR DESCRIPTION
Cette PR automatise le chargement quotidien des données de RDV Service Public, puisqu'il se fait en moins de 15mn et peut donc tourner facilement sur le scheduler Scalingo.

On n'automatise pas encore le chargement des données de rendez-vous insertion, puisque leur staging n'est pas encore sur la zone secnum de Scalingo.