### PR TITLE
cloner les colonnes ENUM vers des colonnes TEXT

### DIFF
--- a/tests/test_etl.rb
+++ b/tests/test_etl.rb
@@ -26,9 +26,10 @@ class TestEtl < Minitest::Test
 
     ActiveRecord::Base.establish_connection "postgresql://rdv_sp_etl_metabase_user:metabase_password@localhost/rdv_sp_etl_test_target"
     users_rows = ActiveRecord::Base.connection.execute(
-      Arel::Table.new("rdvs.users").project(:id, :first_name).to_sql
+      Arel::Table.new("rdvs.users").project(:id, :first_name, :created_through).to_sql
     )
     assert_equal users_rows[0]["first_name"], "[valeur unique anonymisée #{users_rows[0]["id"]}]"
     assert_equal users_rows[1]["first_name"], "[valeur unique anonymisée #{users_rows[1]["id"]}]"
+    assert_equal users_rows[0]["created_through"], "user_sign_up" # colonne ENUM
   end
 end


### PR DESCRIPTION
## Contexte

RDVI nous a signalé que les colonnes de type ENUM ne sont pas présentes sur Metabase.
En effet depuis l’introduction de cet ETL qui utilise un script SQL pour cloner le schéma public vers `rdvs` , `rdvi` etc on ne copie plus les colonnes ENUM.

## Solution

Je ne maîtrise absolument pas assez PostgreSQL pour écrire ces scripts moi-même donc mes solutions se limitent à copier-coller et adapter des scripts trouvés sur internet ou demander à des solutions d’IA de générer le code pour moi.

J’ai essayé en vain de trouver des manières de copier les types ENUM et de les utiliser sur les colonnes dans le schéma cloné.

J’ai finalement essayé en clonant vers des colonnes textuelles et ça semble fonctionner. 
Je n’y vois pas vraiment de limitation, si ce n’est potentiellement des problèmes de perf mais j’imagine que c’est plutôt géré par les indexes que par les types ENUM en eux-même. 
Je suppose que les ENUM permettent surtout de rajouter des contraintes de cohérence à l’écriture dans la db.