### PR TITLE
drop column text_search_terms_with_notification_email

### DIFF
--- a/lib/etl.rb
+++ b/lib/etl.rb
@@ -83,7 +83,7 @@ class Etl
 
     # workaround for a problematic column that we could also exclude
     # ERROR:  cannot insert a non-DEFAULT value into column "text_search_terms" (PG::GeneratedAlways)
-    # DÉTAIL : Column "text_search_terms" is a generated column.
+    # DÉTAIL : Column "text_search_terms" and "text_search_terms_with_notification_email" are generated columns.
     run_sql_command %(ALTER TABLE users DROP COLUMN IF EXISTS text_search_terms CASCADE)
     run_sql_command %(ALTER TABLE users DROP COLUMN IF EXISTS text_search_terms_with_notification_email CASCADE)
 

--- a/lib/etl.rb
+++ b/lib/etl.rb
@@ -85,6 +85,7 @@ class Etl
     # ERROR:  cannot insert a non-DEFAULT value into column "text_search_terms" (PG::GeneratedAlways)
     # DÉTAIL : Column "text_search_terms" is a generated column.
     run_sql_command %(ALTER TABLE users DROP COLUMN IF EXISTS text_search_terms CASCADE)
+    run_sql_command %(ALTER TABLE users DROP COLUMN IF EXISTS text_search_terms_with_notification_email CASCADE)
 
     # STEP : move from public to target schema
     target_schema = app

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -19,9 +19,13 @@ tables:
     truncated: true
   - table_name: user_profiles
     truncated: true
+  - table_name: annotations
+    truncated: true
   - table_name: motif_categories_territories
     truncated: true
   - table_name: schema_migrations
+    truncated: true
+  - table_name: oauth_access_grants
     truncated: true
   - table_name: users
     anonymized_column_names:
@@ -30,6 +34,7 @@ tables:
       - birth_name
       - birth_date
       - email
+      - notification_email
       - unconfirmed_email
       - address
       - address_details
@@ -62,6 +67,7 @@ tables:
       - invitation_accepted_at
       - invitation_created_at
       - text_search_terms
+      - text_search_terms_with_notification_email
       - deleted_at
       - invitation_limit
       - reset_password_sent_at
@@ -83,11 +89,9 @@ tables:
       - email_original
       - encrypted_password
       - unconfirmed_email
-      - cnfs_secondary_email
       - uid
       - external_id
       - calendar_uid
-      - last_sign_in_at
       - reset_password_token
       - confirmation_token
       - invitation_token
@@ -98,6 +102,7 @@ tables:
       - inclusion_connect_open_id_sub
     non_anonymized_column_names:
       - reset_password_sent_at
+      - last_sign_in_at
       - confirmed_at
       - confirmation_sent_at
       - invitation_created_at
@@ -196,6 +201,7 @@ tables:
       - website
       - external_id
       - verticale
+      - ants_connectable
 
   - table_name: absences
     anonymized_column_names:
@@ -215,16 +221,16 @@ tables:
     anonymized_column_names:
       - phone_number
       - phone_number_formatted
+      - name # on pourrait probablement anonymiser le nom uniquement pour les lieux dont availability == single_use
+      - address # idem
     non_anonymized_column_names:
       - created_at
       - updated_at
-      - name
       - old_address
       - latitude
       - longitude
       - old_enabled
       - availability
-      - address
 
   - table_name: participations
     anonymized_column_names:
@@ -411,6 +417,7 @@ tables:
       - controller_name
       - action_name
       - agent_id
+      - authentication_type
 
   - table_name: exports
     non_anonymized_column_names:
@@ -423,3 +430,36 @@ tables:
       - options
       - created_at
       - updated_at
+
+  - table_name: oauth_applications
+    anonymized_column_names:
+      - secret
+    non_anonymized_column_names:
+      - name
+      - uid
+      - redirect_uri
+      - post_logout_redirect_uri
+      - scopes
+      - confidential
+      - created_at
+      - updated_at
+      - logo_base64
+  - table_name: oauth_access_tokens
+    anonymized_column_names:
+      - token
+      - refresh_token
+      - previous_refresh_token
+    non_anonymized_column_names:
+      - scopes
+      - created_at
+      - revoked_at
+      - expires_in
+  - table_name: rdv_plans
+    anonymized_column_names:
+      - return_url
+    non_anonymized_column_names:
+      - duration_in_minutes
+      - starts_at
+      - created_at
+      - updated_at
+      - location_type


### PR DESCRIPTION
Un problème similaire au problème existant sur la colonne `text_search_terms` se produit 

`cannot insert a non-DEFAULT value into column "text_search_terms_with_notification_email" (PG::GeneratedAlways)`