### PR TITLE
Mise à jour de la version de pgsql

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: ankane/setup-postgres@v1
         with:
-          postgres-version: 15
+          postgres-version: 16
       - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/lib/etl.rb
+++ b/lib/etl.rb
@@ -24,7 +24,7 @@ class Etl
 
   def run
     # only useful on Scalingo apps
-    run_command "dbclient-fetcher pgsql 15" if find_executable('dbclient-fetcher')
+    run_command "dbclient-fetcher pgsql 16" if find_executable('dbclient-fetcher')
 
     # STEP : load anonymizer config
     @config = Anonymizer::Config.new(YAML.safe_load(File.read(config_path)))


### PR DESCRIPTION
Cette PR fait en sorte d'utiliser pgsql 16 pour procéder au traitement du dump. Ceci pour éviter cette erreur :
```
pg_dump: error: aborting because of server version mismatch
pg_dump: detail: server version: 16.6 (Debian 16.6-1.pgdg120+1); pg_dump version: 15.8
```
